### PR TITLE
 Trigger a panic when the bitfield is incorrect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl TreeIndex {
 
         flat::full_roots(flat::right_span(next) + 2, &mut roots);
 
-        for root in roots.iter() {
+        for root in &roots {
           if self.get(*root) {
             remote_tree.set(*root);
           }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,13 @@ impl TreeIndex {
 
     while self.bitfield.get(flat::sibling(index)) {
       index = flat::parent(index);
-      if self.bitfield.set(index, true).is_unchanged() {
-        break;
-      }
+      let r = self.bitfield.set(index, true);
+      assert_eq!(
+        r,
+        Change::Changed,
+        "Parent should not be set (parent index: {})",
+        index
+      );
     }
     Change::Changed
   }


### PR DESCRIPTION
This PR makes a hypothetical bug visible by causing a panic instead of ignoring it.

This panic could be softened by using `debug_assert_eq!()` or simply logging the problem, but I think
the broken bitfield should be very visible.

## Checklist
- [x] tests pass

## Semver Changes
Patch level