### PR TITLE
 Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ script: |
   cargo fmt -- --check &&
   cargo build --verbose &&
   cargo test  --verbose &&
-  cargo clippy -- -D clippy
+  cargo clippy -- -D clippy::all
 cache: cargo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl TreeIndex {
     let mut next = index;
     let mut sibling;
     let has_root = digest & 1;
-    digest = digest >> 1;
+    digest >>= 1;
 
     while digest > 0 {
       if digest == 1 && has_root != 0 {
@@ -130,7 +130,7 @@ impl TreeIndex {
       }
 
       next = flat::parent(next);
-      digest = digest >> 1;
+      digest >>= 1;
     }
 
     next = index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ impl TreeIndex {
   /// assert_eq!(tree.blocks(), 4);
   /// tree = TreeIndex::default();
   /// tree.set(3);
-  /// assert_eq!(tree.blocks(), 4); 
+  /// assert_eq!(tree.blocks(), 4);
   /// ```
   #[inline]
   pub fn blocks(&mut self) -> usize {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,3 @@
-#![feature(iterator_step_by)]
-
 extern crate tree_index as tree;
 use tree::{Change, TreeIndex, Verification};
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -284,8 +284,7 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 3, 17].as_slice());
     assert_eq!(proof.verified_by(), 20);
   }
@@ -298,8 +297,7 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 3].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }
@@ -312,8 +310,7 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![8, 13].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }
@@ -326,8 +323,7 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 17].as_slice());
     assert_eq!(proof.verified_by(), 20);
   }
@@ -359,8 +355,7 @@ fn proof_with_a_digest_3() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![16, 7, 25, 28].as_slice());
     assert_eq!(proof.verified_by(), 30);
   }
@@ -381,8 +376,7 @@ fn proof_with_a_digest_3() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      )
-      .unwrap();
+      ).unwrap();
     assert_eq!(proof.nodes(), vec![21].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None
