### PR TITLE
Change from usize to u64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: cargo
 rust: stable
 
 before_script:
-  - rustup component add rustfmt-preview
-  - rustup component add clippy-preview
+  - rustup component add rustfmt
+  - rustup component add clippy
   - cargo fmt --version
   - cargo clippy --version
 
@@ -12,4 +12,4 @@ script:
   - cargo fmt -- --check
   - cargo build --verbose
   - cargo test  --verbose
-  - cargo clippy
+  - cargo clippy -- -D clippy::all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-flat-tree = { version = "4.1.0", git = "https://github.com/bltavares/flat-tree", branch = "usize-to-u64" }
+flat-tree = "5.0.0"
 sparse-bitfield = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-flat-tree = "3.4.0"
-sparse-bitfield = "0.8.1"
+flat-tree = { version = "4.1.0", git = "https://github.com/bltavares/flat-tree", branch = "usize-to-u64" }
+sparse-bitfield = "0.11.0"

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -3,9 +3,9 @@
 /// Merkle trees are proven by checking the parent hashes.
 #[derive(Debug, PartialEq)]
 pub struct Proof<'a> {
-  index: usize,
-  verified_by: usize,
-  nodes: &'a [usize],
+  index: u64,
+  verified_by: u64,
+  nodes: &'a [u64],
 }
 
 impl<'a> Proof<'a> {
@@ -19,7 +19,7 @@ impl<'a> Proof<'a> {
   /// let _proof = Proof::new(0, 0, &nodes);
   /// ```
   #[inline]
-  pub fn new(index: usize, verified_by: usize, nodes: &'a [usize]) -> Self {
+  pub fn new(index: u64, verified_by: u64, nodes: &'a [u64]) -> Self {
     Self {
       index,
       nodes,
@@ -38,7 +38,7 @@ impl<'a> Proof<'a> {
   /// assert_eq!(proof.index(), 0);
   /// ```
   #[inline]
-  pub fn index(&self) -> usize {
+  pub fn index(&self) -> u64 {
     self.index
   }
 
@@ -53,7 +53,7 @@ impl<'a> Proof<'a> {
   /// assert_eq!(proof.verified_by(), 0);
   /// ```
   #[inline]
-  pub fn verified_by(&self) -> usize {
+  pub fn verified_by(&self) -> u64 {
     self.verified_by
   }
 
@@ -68,7 +68,7 @@ impl<'a> Proof<'a> {
   /// assert_eq!(proof.nodes().len(), 0);
   /// ```
   #[inline]
-  pub fn nodes(&self) -> &[usize] {
+  pub fn nodes(&self) -> &[u64] {
     &self.nodes
   }
 }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -2,7 +2,7 @@
 #[derive(Debug, PartialEq)]
 pub struct Verification {
   /// Node that verifies the index.
-  pub node: usize,
+  pub node: u64,
   /// The highest Node found.
-  pub top: usize,
+  pub top: u64,
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -96,7 +96,7 @@ fn verified_by() {
   verify(&mut index, 18, 30, 28);
   verify(&mut index, 17, 30, 28);
 
-  fn verify(tree: &mut TreeIndex, index: usize, node: usize, top: usize) {
+  fn verify(tree: &mut TreeIndex, index: u64, node: u64, top: u64) {
     assert_eq!(tree.verified_by(index), Verification { node, top });
   }
 }
@@ -282,7 +282,8 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 3, 17].as_slice());
     assert_eq!(proof.verified_by(), 20);
   }
@@ -295,7 +296,8 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 3].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }
@@ -308,7 +310,8 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![8, 13].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }
@@ -321,7 +324,8 @@ fn proof_with_a_digest_2() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![8, 13, 17].as_slice());
     assert_eq!(proof.verified_by(), 20);
   }
@@ -353,7 +357,8 @@ fn proof_with_a_digest_3() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![16, 7, 25, 28].as_slice());
     assert_eq!(proof.verified_by(), 30);
   }
@@ -374,7 +379,8 @@ fn proof_with_a_digest_3() {
         false,
         &mut nodes,
         &mut TreeIndex::default(),
-      ).unwrap();
+      )
+      .unwrap();
     assert_eq!(proof.nodes(), vec![21].as_slice());
     assert_eq!(proof.verified_by(), 0);
   }


### PR DESCRIPTION
On [random-access-storage](https://github.com/datrs/random-access-storage)
issue
https://github.com/datrs/random-access-storage/issues/6 has changed all
types from `usize` into `u64` to be able to handle more than 4gbs on
32bits systems.

> usize is 32 bits on a 32 bit system, so the storage would be limited
to 4GB on such a system.

When changing `random-access-storage` on `hypercore` (tracking:
https://github.com/datrs/hypercore/pull/100) one of the things I've
noticed is that it wold be easier to also make `tree-index` use
`u64` to integrate with `random-access-storage`. Very likely, this also
means that we would need to bump to use more than 32Gb storages on
`tree-index`.

I've simply changed all declarations of usize into u64. All tests are
passing.

It also fixes Travis CI and update libraries to latest version.

Needs:
---

- [ ] https://github.com/datrs/flat-tree/pull/44

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
