### PR TITLE
added as_bitfield() -> &Bitfield method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,11 @@ impl TreeIndex {
 
     Verification { node, top }
   }
+
+  /// Get a reference to underlying bitfield
+  pub fn as_bitfield(&self) -> &Bitfield {
+    &self.bitfield
+  }
 }
 
 /// Create a TreeIndex with an empty sparse_bitfield instance with a page size


### PR DESCRIPTION
this allows calling methods on underlying bitfield, for example
requesting its page_size or converting it to bytes vec


a 🙋 feature

## Checklist
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
this would help creating Feed instances in dat.rs/hypercore

## Semver Changes
patch level? this doesnt break anything
